### PR TITLE
Sleep longer, show progress, and other improvements

### DIFF
--- a/src/steam-mass-ignore.user.js
+++ b/src/steam-mass-ignore.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name            Steam mass ignore
 // @description     massively ignore games, DLC, items on Steam
-// @version         0.2.1
+// @version         0.2.2
 // @author          Sébastien Aperghis-Tramoni
 // @copyright       2022 Sébastien Aperghis-Tramoni
 // @license         MIT
@@ -35,7 +35,7 @@
     }
 
 
-    async function ignore_appid(appid) {
+    function ignore_appid(appid) {
         var payload = "sessionid=" + sessionid
                     + "&appid=" + appid
                     + "&remove=0";
@@ -63,35 +63,34 @@
             if (appid && !skip) {
                 appid = appid.nodeValue;
                 console.log("- ignoring appid:" + appid);
-                button.innerHTML = "Ignore all" + ".".repeat(1 + i % 3);
+                button.textContent = `Ignore all: ${i}/${rows.length}`;
                 ignore_appid(appid);
-                await sleep(100);
+                await sleep(500);
             }
         }
-
-        button.innerHTML = "Ignore all: done";
+        button.textContent = `Ignore all: ${rows.length} done`;
     }
 
 
-    async function ignore_all_dlc (event) {
+    function ignore_all_dlc (event) {
         console.log(">>> ignore_all_dlc()");
         loop_ignore(event, "game_area_dlc_row");
     }
 
 
-    async function ignore_in_bundle_sub (event) {
+    function ignore_in_bundle_sub (event) {
         console.log(">>> ignore_in_bundle_sub()");
         loop_ignore(event, "tablet_list_item");
     }
 
 
-    async function ignore_in_search_result (event) {
+    function ignore_in_search_result (event) {
         console.log(">>> ignore_in_search_result()");
         loop_ignore(event, "search_result_row");
     }
 
 
-    async function ignore_in_curator_page (event) {
+    function ignore_in_curator_page (event) {
         console.log(">>> ignore_in_curator_page()");
         loop_ignore(event, "store_capsule");
     }
@@ -103,7 +102,7 @@
     // create [ignore] button
     var ignore_button = document.createElement("a");
     ignore_button.id = "ignore_all_dlc_button";
-    ignore_button.appendChild(document.createTextNode("Ignore all"));
+    ignore_button.textContent = "Ignore all";
 
     var ignore_span = document.createElement("span");
     ignore_span.className = "note";


### PR DESCRIPTION
* Increasing the interval between each request from 100 to 500. This prevents hitting API limits on Steam servers. I have not tried other values, so smaller values such as 400 or 300 are likely okay too.
* Removed `async` declarations from functions that do not use `await`.
* Removed `innerHTML`, and replaced with (much safer) `textContent`.
* Shows the current progress in the label (e.g. 4/42).

---

Also, you may want to suggest your script to https://steamcommunity.com/groups/Sentinels_of_the_Store/discussions

Or even consider contributing it to https://github.com/IsThereAnyDeal/AugmentedSteam